### PR TITLE
Duplicate message refactor

### DIFF
--- a/lib/jdiscovery/jregistrar.js
+++ b/lib/jdiscovery/jregistrar.js
@@ -195,8 +195,8 @@ function Registrar(app, machType, id, port, config) {
             }
         });
 
-        this.mdnsRegistry.on('discovery', function(attr, event, nodeId, value) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value);
+        this.mdnsRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
         });
 
         this.mdnsRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -205,8 +205,8 @@ function Registrar(app, machType, id, port, config) {
     }
 
     if (this.localRegistry) {
-        this.localRegistry.on('discovery', function(attr, event, nodeId, value) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value);
+        this.localRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
         });
 
         this.localRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -547,31 +547,21 @@ Registrar.prototype._reformatAttrsToRemove = function(attrs) {
 /**
  * Upon receipt of a discovery event, pass it onto the rest of the application if it is not a duplicate
  */
-Registrar.prototype._respondToDiscoveryEvent = function(self, attr, event, nodeId, value) {
-
-    self.emit(event, nodeId, value);
-
-    // Mahesh: Duplicate detection has been turned off.
-    // This is causing lot of problems. The duplicate detection was used to eliminate
-    // MQTT/MDNS/LocalStorage giving duplicate advertisements.
-
-    // This should be done differently. We need to give MDNS high priority
-    // Next we should have MQTT and last we should have LocalStorage.
-    // The best way to give priority and eliminate duplicates should be figured out.
-
-    // For now, we will use only one discovery service at a time.
-    // MQTT is the best choice.
-
-    // if (!self._isDuplicate(self, attr, nodeId, value)) {
-    //     self._updateDiscoveries(self, attr, nodeId, value);
-    //     self.emit(event, nodeId, value);
-    // }
+Registrar.prototype._respondToDiscoveryEvent = function(self, attr, event, nodeId, value, msgId) {
+    if (!self._isDuplicate(self, attr, nodeId, msgId)) {
+        self._updateDiscoveries(self, attr, nodeId, msgId);
+        self.emit(event, nodeId, value);
+    }
 }
 
 /**
- * Returns true if a discovery is a duplicate and false otherwise
+ * Returns true if a discovery is a duplicate and false otherwise.
+ * attr - the attrubute for which a discovery was made
+ * nodeId - the ID of the node for which the discovery was made
+ * msgId - the ID corresponding to the bit of information we discovered about the node.
+ *  This is how we know whether or not the discovery is a duplicate or not.
  */
-Registrar.prototype._isDuplicate = function(self, attr, nodeId, value) {
+Registrar.prototype._isDuplicate = function(self, attr, nodeId, msgId) {
     if (!self.discoveries.hasOwnProperty(attr)) {
         return false;
     }
@@ -580,15 +570,15 @@ Registrar.prototype._isDuplicate = function(self, attr, nodeId, value) {
         return false;
     }
 
-    // compare the values
-    return equivalentValues(value, self.discoveries[attr][nodeId]);
+    // compare the ID of the last message with that of the current message
+    return self.discoveries[attr][nodeId] != msgId;
 }
 
-Registrar.prototype._updateDiscoveries = function(self, attr, nodeId, value) {
+Registrar.prototype._updateDiscoveries = function(self, attr, nodeId, msgId) {
     if (!self.discoveries.hasOwnProperty(attr)) {
         self.discoveries[attr] = {};
     }
-    self.discoveries[attr][nodeId] = value;
+    self.discoveries[attr][nodeId] = msgId;
 }
 
 Registrar.prototype._retry = function(self, protocol) {

--- a/lib/jdiscovery/jregistrar.js
+++ b/lib/jdiscovery/jregistrar.js
@@ -4,73 +4,11 @@ var EventEmitter = require('events'),
     MQTTRegistry = require('./mqttregistry'),
     MDNSRegistry = require('./mdnsregistry'),
     LocalRegistry = require('./localregistry'),
-    os = require('os'),
-    Registry = require('./registry');
+    os = require('os');
 
 //==============================================================================
 // Helpers
 //==============================================================================
-
-/**
- * Returns true if two values are equivalent and false otherwise
- */
-function equivalentValues(a, b) {
-    // base cases
-    if ((typeof a == 'number' && typeof b == 'number') ||
-        (typeof a == 'string' && typeof b == 'string')) {
-            return a == b;
-    }
-
-    if ((a == null && b == null) ||
-        (a == undefined && b == undefined)) {
-            return true;
-    }
-
-    if (a instanceof Array && b instanceof Array) {
-        // recursive case 1
-        return equivalentArrays(a, b);
-    } else if (a instanceof Object && b instanceof Object) {
-        // recursive case 2
-        return equivalentObjects(a, b);
-    }
-
-    return false;
-}
-
-/**
- * Returns true if two arrays are equivalent or false otherwise
- * Note: Currently returns false for two arrays with the same elements but in a different order
- */
-function equivalentArrays(a, b) {
-    if (a.length != b.length) {
-        return false;
-    }
-
-    for (var i = 0; i < a.length; i++) {
-        if (!equivalentValues(a[i], b[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/**
- * Returns true if two objects are equivalent and false otherwise
- */
-function equivalentObjects(a, b) {
-    if (Object.keys(a).length != Object.keys(b).length) {
-        return false;
-    }
-
-    for (var key in a) {
-        if (!b.hasOwnProperty(key) || !equivalentValues(a[key], b[key])) {
-            return false;
-        }
-    }
-
-    return true;
-}
 
 /**
  * returns the IPv4 address of the node
@@ -89,31 +27,47 @@ function getIPv4Address() {
 
 //==============================================================================
 // Registrar Class
-// This Class is the interface between the application and the MQTT, mDNS, and
+// This class is the interface between the application and the MQTT, mDNS, and
 // local storage registries
 //==============================================================================
 
 function Registrar(app, machType, id, port, config) {
     // the name of the application
     this.app = app;
-    // the type of this machine
+    // the type of the machine the registar is running on (device, fog, or cloud)
     this.machType = machType;
-    // the id of this machine
+    // the id of the machine
     this.id = id;
     // the port the program is running on
     this.port = port;
 
-    // store discoveries so that we can easily check for duplicates
+    /*
+     * Store discoveries so that we can easily check for duplicates.
+     * discoveries is an object which maps from an attribute name, e.g. 'status' to
+     * a map of <node ID, message ID> pairs. e.g. if discoveries looks like:
+     *  {
+     *      status: {
+     *          a: 123,
+     *          b: 456
+     *      }
+     *  }
+     * then we know that the last message received from node 'a' regarding the
+     * 'attribute' status had ID 123.
+     */
     this.discoveries = {};
 
-    // reserved attributes
+    /**
+     * Reserved attributes.
+     * These are attribute names that cannot be used by third parties.
+     */
     this.reservedAttrs = ['status', 'lastCheckIn', 'createdAt', 'updatedAt'];
 
+    // whether or not this registrar has been started
     this.started = false;
 
-    //==========================================================================
-    // config-specific set-up
-    //==========================================================================
+    /**
+     * config-specific set-up
+     */
 
     var noProtocols = true;
 
@@ -138,9 +92,10 @@ function Registrar(app, machType, id, port, config) {
         throw new Error('a Registrar must use at least one protocol');
     }
 
-    // set up default attributes, which are the same for devices, fogs, and clouds (i.e. just status)
-    // default attributes:
-    // status
+    /**
+     * Set up default attributes, which are the same for devices, fogs, and clouds.
+     * The only default attribute is 'status'.
+     */
     this.addAttributes({
         status: function() {
             return {
@@ -150,8 +105,10 @@ function Registrar(app, machType, id, port, config) {
         }
     }, true);
 
-    // prep the default discoveries to be made by a node:
-    // devices discover fogs and fogs discover clouds
+    /**
+     * Prep the default discoveries to be made by a node:
+     * devices discover fogs and fogs discover clouds.
+     */
     if (this.machType === globals.NodeType.DEVICE) {
         // default discoveries:
         // devices discover fogs
@@ -182,7 +139,7 @@ function Registrar(app, machType, id, port, config) {
             }
         });
     } else {
-        // no default cloud discoveries!
+        // If this node is a cloud, then it discovers nothing by default!
     }
 
     // listen for events from the Registries
@@ -212,8 +169,8 @@ function Registrar(app, machType, id, port, config) {
             setTimeout(self.mqttRegistry.unpublish, constants.mqtt.longRetryInterval, self, attr);
         });
 
-        this.mqttRegistry.on('discovery', function(attr, event, nodeId, value) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value);
+        this.mqttRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
         });
 
         this.mqttRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -326,15 +283,17 @@ Registrar.prototype.addAttributes = function(attrs, override) {
     if (!override) {
         this._checkFormOfAttrsToAdd(attrs);
     }
+    // use the time corresponding to the publication of these attributes as the message ID
+    const msgId = Date.now();
     // add the attributes on each protocol
     if (this.mqttRegistry) {
-        this.mqttRegistry.addAttributes(attrs);
+        this.mqttRegistry.addAttributes(attrs, msgId);
     }
     if (this.mdnsRegistry) {
-        this.mdnsRegistry.addAttributes(attrs);
+        this.mdnsRegistry.addAttributes(attrs, msgId);
     }
     if (this.localRegistry) {
-        this.localRegistry.addAttributes(attrs);
+        this.localRegistry.addAttributes(attrs, msgId);
     }
 }
 
@@ -354,16 +313,16 @@ Registrar.prototype.removeAttributes = function(attrs) {
 }
 
 /**
- * Specify attributes to be discovered
- attrs can have one of the following forms:
- (a)
-    {
-        all: {attr: event}, // discover these attributes for all nodes
-        device: {attr: event}, // discover these attributes just for devices
-        fog: {attr: event}, // discover these attributes just for fogs
-        cloud: {attr: event} // discover these attributes just for clouds
-    }
- (b) As a shortcut for all, one can simply pass an object of <attr, event> pairs
+ * Specify attributes to be discovered.
+ * dattrs can have one of the following forms:
+ * (a)
+ *    {
+ *        all: {attr: event}, // discover these attributes for all nodes
+ *        device: {attr: event}, // discover these attributes just for devices
+ *        fog: {attr: event}, // discover these attributes just for fogs
+ *        cloud: {attr: event} // discover these attributes just for clouds
+ *    }
+ * (b) As a shortcut for all, one can simply pass an object of <attr, event> pairs
  */
 Registrar.prototype.discoverAttributes = function(dattrs) {
     dattrs = this._checkAndReformatAttrsToDiscover(dattrs);
@@ -402,7 +361,7 @@ Registrar.prototype.stopDiscoveringAttributes = function(dattrs) {
 Registrar.prototype._checkAndReformatAttrsToDiscover = function(attrs) {
     // error handling
     if (typeof attrs !== 'object') {
-        throw new Error('you must specity the attributes you want discovered as an object - see the docs');
+        throw new Error('you must specify the attributes you want discovered as an object - see the docs');
     }
     // check that the attrs parameter is properly formed
     var formedAttrs;

--- a/lib/jdiscovery/jregistrar.js
+++ b/lib/jdiscovery/jregistrar.js
@@ -169,8 +169,8 @@ function Registrar(app, machType, id, port, config) {
             setTimeout(self.mqttRegistry.unpublish, constants.mqtt.longRetryInterval, self, attr);
         });
 
-        this.mqttRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
+        this.mqttRegistry.on('discovery', function(attr, event, nodeId, value, dedupeId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, dedupeId);
         });
 
         this.mqttRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -195,8 +195,8 @@ function Registrar(app, machType, id, port, config) {
             }
         });
 
-        this.mdnsRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
+        this.mdnsRegistry.on('discovery', function(attr, event, nodeId, value, dedupeId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, dedupeId);
         });
 
         this.mdnsRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -205,8 +205,8 @@ function Registrar(app, machType, id, port, config) {
     }
 
     if (this.localRegistry) {
-        this.localRegistry.on('discovery', function(attr, event, nodeId, value, msgId) {
-            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, msgId);
+        this.localRegistry.on('discovery', function(attr, event, nodeId, value, dedupeId) {
+            self._respondToDiscoveryEvent(self, attr, event, nodeId, value, dedupeId);
         });
 
         this.localRegistry.on('attr-removed', function(attr, event, nodeId) {
@@ -284,16 +284,16 @@ Registrar.prototype.addAttributes = function(attrs, override) {
         this._checkFormOfAttrsToAdd(attrs);
     }
     // use the time corresponding to the publication of these attributes as the message ID
-    const msgId = Date.now();
+    const dedupeId = Date.now();
     // add the attributes on each protocol
     if (this.mqttRegistry) {
-        this.mqttRegistry.addAttributes(attrs, msgId);
+        this.mqttRegistry.addAttributes(attrs, dedupeId);
     }
     if (this.mdnsRegistry) {
-        this.mdnsRegistry.addAttributes(attrs, msgId);
+        this.mdnsRegistry.addAttributes(attrs, dedupeId);
     }
     if (this.localRegistry) {
-        this.localRegistry.addAttributes(attrs, msgId);
+        this.localRegistry.addAttributes(attrs, dedupeId);
     }
 }
 
@@ -547,9 +547,9 @@ Registrar.prototype._reformatAttrsToRemove = function(attrs) {
 /**
  * Upon receipt of a discovery event, pass it onto the rest of the application if it is not a duplicate
  */
-Registrar.prototype._respondToDiscoveryEvent = function(self, attr, event, nodeId, value, msgId) {
-    if (!self._isDuplicate(self, attr, nodeId, msgId)) {
-        self._updateDiscoveries(self, attr, nodeId, msgId);
+Registrar.prototype._respondToDiscoveryEvent = function(self, attr, event, nodeId, value, dedupeId) {
+    if (!self._isDuplicate(self, attr, nodeId, dedupeId)) {
+        self._updateDiscoveries(self, attr, nodeId, dedupeId);
         self.emit(event, nodeId, value);
     }
 }
@@ -558,10 +558,9 @@ Registrar.prototype._respondToDiscoveryEvent = function(self, attr, event, nodeI
  * Returns true if a discovery is a duplicate and false otherwise.
  * attr - the attrubute for which a discovery was made
  * nodeId - the ID of the node for which the discovery was made
- * msgId - the ID corresponding to the bit of information we discovered about the node.
- *  This is how we know whether or not the discovery is a duplicate or not.
+ * dedupeId - an ID that tells us if this message is a duplicate or not
  */
-Registrar.prototype._isDuplicate = function(self, attr, nodeId, msgId) {
+Registrar.prototype._isDuplicate = function(self, attr, nodeId, dedupeId) {
     if (!self.discoveries.hasOwnProperty(attr)) {
         return false;
     }
@@ -570,15 +569,15 @@ Registrar.prototype._isDuplicate = function(self, attr, nodeId, msgId) {
         return false;
     }
 
-    // compare the ID of the last message with that of the current message
-    return self.discoveries[attr][nodeId] != msgId;
+    // compare the dedupe ID of the last message with that of the current message
+    return self.discoveries[attr][nodeId] != dedupeId;
 }
 
-Registrar.prototype._updateDiscoveries = function(self, attr, nodeId, msgId) {
+Registrar.prototype._updateDiscoveries = function(self, attr, nodeId, dedupeId) {
     if (!self.discoveries.hasOwnProperty(attr)) {
         self.discoveries[attr] = {};
     }
-    self.discoveries[attr][nodeId] = msgId;
+    self.discoveries[attr][nodeId] = dedupeId;
 }
 
 Registrar.prototype._retry = function(self, protocol) {

--- a/lib/jdiscovery/jregistrar.js
+++ b/lib/jdiscovery/jregistrar.js
@@ -569,8 +569,10 @@ Registrar.prototype._isDuplicate = function(self, attr, nodeId, dedupeId) {
         return false;
     }
 
-    // compare the dedupe ID of the last message with that of the current message
-    return self.discoveries[attr][nodeId] != dedupeId;
+    // Compare the dedupe ID of the last message with that of the current message
+    // Because the dedupe IDs are timestamps, we say that a message is a duplicate
+    // if its ID is less than or equal to the last received.
+    return self.discoveries[attr][nodeId] >= dedupeId;
 }
 
 Registrar.prototype._updateDiscoveries = function(self, attr, nodeId, dedupeId) {

--- a/lib/jdiscovery/localregistry.js
+++ b/lib/jdiscovery/localregistry.js
@@ -22,7 +22,11 @@ function LocalRegistry(app, machType, id, port) {
     this.lastScanAt = 0;
     this.currentOfflineMachs = {};
 
-    // attributes to write to local storage the next time we check in
+    /**
+     * Attributes to write to local storage the next time we check in. A map from
+     * attribute name to { payload: attribute_value, dedupeId: deduplication_id }
+     * objects.
+     */
     this.attrsToAdd = {};
     // attributes to remove from local storage the next time we check in
     this.attrsToRemove = [];
@@ -47,15 +51,7 @@ LocalRegistry.prototype.constructor = LocalRegistry;
 /**
  * API for local storage registration/discovery
  */
-LocalRegistry.prototype.registerAndDiscover = function(options) {
-    if (options !== undefined) {
-        // parse options
-        // attributes
-        this.addAttributes(options.attrsToAdd);
-        // attrsToDiscover
-        this.discoverAttributes(options.attrsToDiscover);
-    }
-
+LocalRegistry.prototype.registerAndDiscover = function() {
     if (!this.started) {
         // initialize the local storage
         var self = this;
@@ -116,14 +112,16 @@ LocalRegistry.prototype._kickStartCheckIns = function(self) {
 
     // add attrs
     for (var attr in self.attrsToAdd) {
-        if (self.attrsToAdd[attr] instanceof Function) {
+        if (self.attrsToAdd[attr].payload instanceof Function) {
             data[attr] = {
-                payload: self.attrsToAdd[attr](),
+                payload: self.attrsToAdd[attr].payload(),
+                id: self.attrsToAdd[attr].dedupeId,
                 updatedAt: now
             };
         } else {
             data[attr] = {
-                payload: self.attrsToAdd[attr],
+                payload: self.attrsToAdd[attr].payload,
+                id: self.attrsToAdd[attr].dedupeId,
                 updatedAt: now
             };
         }
@@ -187,14 +185,16 @@ LocalRegistry.prototype._checkIn = function(self, attemptNumber) {
         self.attrsToRemove = [];
         // add any that need adding
         for (var attr in self.attrsToAdd) {
-            if (self.attrsToAdd[attr] instanceof Function) {
+            if (self.attrsToAdd[attr].payload instanceof Function) {
                 nodes[self.id][attr] = {
-                    payload: self.attrsToAdd[attr](),
+                    payload: self.attrsToAdd[attr].payload(),
+                    id: self.attrsToAdd[attr].dedupeId,
                     updatedAt: now
                 };
             } else {
                 nodes[self.id][attr] = {
-                    payload: self.attrsToAdd[attr],
+                    payload: self.attrsToAdd[attr].payload,
+                    id: self.attrsToAdd[attr].dedupeId,
                     updatedAt: now
                 };
             }
@@ -267,21 +267,21 @@ LocalRegistry.prototype._makeDiscoveries = function(self, machs, dattrs) {
         for (var attr in dattrs) {
             if (attr === 'status') {
                 // check if the node has gone offline
-                if ((now - machs[machId].lastCheckIn) > 2 * constants.localStorage.checkInInterval) {
+                if ((now - machs[machId].lastCheckIn) > 3 * constants.localStorage.checkInInterval) {
                     // if we haven't already noted that the machine is offline...
                     if (!self.currentOfflineMachs[machId]) {
                         self.currentOfflineMachs[machId] = true;
-                        self.emit('discovery', 'status', dattrs[attr].offline, machId, 'offline');
+                        self.emit('discovery', 'status', dattrs[attr].offline, machId, 'offline', machs[machId].status.id);
                     }
                 } else if (machs[machId].createdAt > self.lastScanAt) {
                     // the node is newly online (or was online before the current node went online)
-                    self.emit('discovery', 'status', dattrs[attr].online, machId, machs[machId].status.payload);
+                    self.emit('discovery', 'status', dattrs[attr].online, machId, machs[machId].status.payload, machs[machId].status.id);
                     // in case we currently have this node recorded as offline
                     delete self.currentOfflineMachs[machId];
                 }
             } else {
                 if (machs[machId].hasOwnProperty(attr) && machs[machId][attr].updatedAt > self.lastScanAt) {
-                    self.emit('discovery', attr, dattrs[attr].onAdd, machId, machs[machId][attr].payload);
+                    self.emit('discovery', attr, dattrs[attr].onAdd, machId, machs[machId][attr].payload, machs[machId][attr].id);
                 }
             }
         }
@@ -306,10 +306,10 @@ LocalRegistry.prototype._detectRemovedAttrs = function(self, machs, dattrs) {
 /**
  * Add custom, discoverable attributes on the node
  */
-LocalRegistry.prototype.addAttributes = function(attrs) {
+LocalRegistry.prototype.addAttributes = function(attrs, dedupeId) {
     for (var attr in attrs) {
         delete this.attrsToRemove[attr];
-        this.attrsToAdd[attr] = attrs[attr];
+        this.attrsToAdd[attr] = { payload: attrs[attr], dedupeId: dedupeId };
     }
 }
 

--- a/lib/jdiscovery/mdnsregistry.js
+++ b/lib/jdiscovery/mdnsregistry.js
@@ -28,22 +28,14 @@ function MDNSRegistry(app, machType, id, port) {
 MDNSRegistry.prototype = Object.create(Registry.prototype);
 MDNSRegistry.prototype.constructor = MDNSRegistry;
 
-MDNSRegistry.prototype.registerAndDiscover = function(options) {
+MDNSRegistry.prototype.registerAndDiscover = function() {
     this.started = true;
 
     // start any ads and browsers created before this function was called
-    this.addAttributes(this.attrs);
-    this.discoverAttributes(this.attrsToDiscover);
-
-    // add any new attributes or desired discoveries
-    if (options) {
-        if (options.attrsToAdd) {
-            this.addAttributes(options.attrsToAdd);
-        }
-        if (options.attrsToDiscover) {
-            this.discoverAttributes(options.attrsToDiscover);
-        }
+    for (var attr in this.attrs) {
+        this._createAdvertisements({ attr: this.attrs[attr].payload }, this.attrs[attr].dedupeId);
     }
+    this.discoverAttributes(this.attrsToDiscover);
 }
 
 //------------------------------------------------------------------------------
@@ -53,7 +45,7 @@ MDNSRegistry.prototype.registerAndDiscover = function(options) {
 /**
  * Creates advertisements for the provided attributes
  */
-MDNSRegistry.prototype._createAdvertisements = function(attrs) {
+MDNSRegistry.prototype._createAdvertisements = function(attrs, dedupeId) {
     for (var attr in attrs) {
         // stop advertisement of existing attr (we'll just replace it)
         if (this.ads[attr]) {
@@ -65,13 +57,15 @@ MDNSRegistry.prototype._createAdvertisements = function(attrs) {
         if (attrs[attr] instanceof Function) {
             txtRecord = {
                 msg: JSON.stringify({
-                    payload: attrs[attr]()
+                    payload: attrs[attr](),
+                    id: dedupeId
                 })
             };
         } else {
             txtRecord = {
                 msg: JSON.stringify({
-                    payload: attrs[attr]
+                    payload: attrs[attr],
+                    id: dedupeId
                 })
             };
         }
@@ -180,7 +174,8 @@ MDNSRegistry.prototype._browse = function(self, attr, machType, events) {
         }
 
         // emit a discovery event!
-        self.emit('discovery', attr, events.onAdd, service.name, JSON.parse(service.txtRecord.msg).payload);
+        const parsedMsg = JSON.parse(service.txtRecord.msg);
+        self.emit('discovery', attr, events.onAdd, service.name, parsedMsg.payload, parsedMsg.id);
     });
 
     browser.on('serviceDown', function(service) {
@@ -230,14 +225,17 @@ MDNSRegistry.prototype._browseForStatus = function(self, machType, events) {
 //==============================================================================
 
 /**
- * Just an alias for _createAdertisements, i.e. adds attributes by starting ads
+ * Adds attributes by starting ads.
+ * attrs - an object of attributes
+ * dedupeId - the ID to publish with the attributes for deduplication purposes
+ *  on the receiving node
  */
-MDNSRegistry.prototype.addAttributes = function(attrs) {
+MDNSRegistry.prototype.addAttributes = function(attrs, dedupeId) {
     if (this.started) {
-        this._createAdvertisements(attrs);
+        this._createAdvertisements(attrs, dedupeId);
     } else {
         for (var attr in attrs) {
-            this.attrs[attr] = attrs[attr];
+            this.attrs[attr] = { payload: attrs[attr], dedupeId: dedupeId };
         }
     }
 }

--- a/lib/jdiscovery/mqttregistry.js
+++ b/lib/jdiscovery/mqttregistry.js
@@ -16,7 +16,7 @@ function MQTTRegistry(app, machType, id, port, subQos, pubQos) {
 
     /**
      * Attributes currently published. A map from attribute name
-     * to { payload: attribute_value, id: msg_id } objects.
+     * to { payload: attribute_value, dedupeId: deduplication_id } objects.
      */
     this.publishedAttrs = {};
     // attributes that have already been subscribed to
@@ -27,7 +27,7 @@ function MQTTRegistry(app, machType, id, port, subQos, pubQos) {
     };
     /**
      * Attributes to be published on (re)connection. A map from attribute name
-     * to { payload: attribute_value, id: msg_id } objects.
+     * to { payload: attribute_value, dedupeId: deduplication_id } objects.
      */
     this.attrsToPublish = {};
     // attributes to remove when reconnecting
@@ -53,17 +53,7 @@ MQTTRegistry.prototype.constructor = MQTTRegistry;
 /**
  * Performs basic registration and discovery
  */
-MQTTRegistry.prototype.registerAndDiscover = function(options) {
-
-    if (options) {
-        if (options.attrsToAdd) {
-            this.addAttributes(options.attrsToAdd);
-        }
-        if (options.attrsToDiscover) {
-            this.discoverAttributes(options.attrsToDiscover);
-        }
-    }
-
+MQTTRegistry.prototype.registerAndDiscover = function() {
     // create an mqtt client
     this.client = mqtt.connect(constants.mqtt.brokerUrl, this._getConnectionOptions());
 
@@ -125,7 +115,7 @@ MQTTRegistry.prototype._prepareForEvents = function() {
         }
         self.publishedAttrs = {};
         for (var attr in self.attrsToPublish) {
-            self._publishWithRetries(self, attr, self.attrsToPublish[attr][payload], self.attrsToPublish[attr][id], constants.mqtt.retries);
+            self._publishWithRetries(self, attr, self.attrsToPublish[attr][payload], self.attrsToPublish[attr][dedupeId], constants.mqtt.retries);
         }
         // unpublish
         for (var attr in self.attrsToRemove) {
@@ -175,7 +165,7 @@ MQTTRegistry.prototype._prepareForEvents = function() {
  * Handles receipt of a message from the MQTT broker. Finds the subscription that
  * the message corresponds to and executes the appropriate action.
  */
-MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, payload, id) {
+MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, payload, dedupeId) {
     var eventName;
     if (self.subscribedAttrs[machType].hasOwnProperty(attr)) {
         if (attr === 'status') {
@@ -190,7 +180,7 @@ MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, p
     }
 
     if (eventName !== undefined) {
-        self.emit('discovery', attr, eventName, machId, payload, id);
+        self.emit('discovery', attr, eventName, machId, payload, dedupeId);
     } else {
         console.log('Message received yet we are not subscribed to this message channel, or shouldn\'t be... This should not be because we are still awaiting a subscription confirmation for this message, as this issue has been fixed. If you ever see this message, then something is probably wrong.');
     }
@@ -357,26 +347,27 @@ MQTTRegistry.prototype.unsubscribe = function(self, dattrs) {
  * Helper for publishing an attribute with retries.
  * attr - the name of the attribute
  * value - the value of the attribute
- * msgId - the ID of the publication
+ * dedupeId - the ID to publish with the attributes for deduplication purposes on
+ *  on the receiving node
  * retries - the number of retries, if publishing fails
  */
-MQTTRegistry.prototype._publishWithRetries = function(self, attr, value, msgId, retries) {
+MQTTRegistry.prototype._publishWithRetries = function(self, attr, value, dedupeId, retries) {
     var msg;
     if (value instanceof Function) {
-        msg = JSON.stringify({ payload: value(), id: msgId });
+        msg = JSON.stringify({ payload: value(), id: dedupeId });
     } else {
-        msg = JSON.stringify({ payload: value, id: msgId });
+        msg = JSON.stringify({ payload: value, id: dedupeId });
     }
     self.client.publish(self.app + '/' + self.machType + '/' + self.id + '/' + attr, msg, {qos: self.pubQos, retain: true}, function (err) {
         if (err) {
             if (retries === 0) {
-                setTimeout(self._publishWithRetries, constants.mqtt.retryInterval, self, attr, value, msgId, retries - 1);
+                setTimeout(self._publishWithRetries, constants.mqtt.retryInterval, self, attr, value, dedupeId, retries - 1);
             } else {
                 self.emit('pub-error', self, attr, value);
             }
         } else {
             // move the attribute from attrsToPublish to publishedAttrs
-            self.publishedAttrs[attr] = { payload: value, id: msgId };
+            self.publishedAttrs[attr] = { payload: value, dedupeId: dedupeId };
             delete self.attrsToPublish[attr];
         }
     });
@@ -446,16 +437,16 @@ MQTTRegistry.prototype._getConnectionOptions = function() {
 /**
  * Add and publish attributes for this node
  */
-MQTTRegistry.prototype.addAttributes = function(attrs, msgId) {
+MQTTRegistry.prototype.addAttributes = function(attrs, dedupeId) {
     for (var attr in attrs) {
         // just in case this is in the queue for removal...
         delete this.attrsToRemove[attr];
         // check that it's not already published
         if (!this.publishedAttrs.hasOwnProperty(attr)) {
-            this.attrsToPublish[attr] = { payload: attrs[attr], id: msgId };
+            this.attrsToPublish[attr] = { payload: attrs[attr], dedupeId: dedupeId };
             if (this.client && this.client.connected) {
                 // try to publish the attribute
-                this._publishWithRetries(this, attr, attrs[attr], msgId, constants.mqtt.retries);
+                this._publishWithRetries(this, attr, attrs[attr], dedupeId, constants.mqtt.retries);
             }
         }
     }

--- a/lib/jdiscovery/mqttregistry.js
+++ b/lib/jdiscovery/mqttregistry.js
@@ -14,7 +14,10 @@ function MQTTRegistry(app, machType, id, port, subQos, pubQos) {
     // the quality of service to use for publications
     this.pubQos = pubQos;
 
-    // attributes that have already been published
+    /**
+     * Attributes currently published. A map from attribute name
+     * to { payload: attribute_value, id: msg_id } objects.
+     */
     this.publishedAttrs = {};
     // attributes that have already been subscribed to
     this.subscribedAttrs = {
@@ -22,7 +25,10 @@ function MQTTRegistry(app, machType, id, port, subQos, pubQos) {
         fog: {},
         cloud: {}
     };
-    // attributes to be published on (re)connection
+    /**
+     * Attributes to be published on (re)connection. A map from attribute name
+     * to { payload: attribute_value, id: msg_id } objects.
+     */
     this.attrsToPublish = {};
     // attributes to remove when reconnecting
     this.attrsToRemove = {};
@@ -101,18 +107,6 @@ MQTTRegistry.prototype._prepareForEvents = function() {
                 cloud: {}
             };
             self._subscribeWithRetries(self, JSON.parse(JSON.stringify(self.attrsToSubTo)), constants.mqtt.retries);
-            // publish
-            for (var attr in self.publishedAttrs) {
-                self.attrsToPublish[attr] = self.publishedAttrs[attr];
-            }
-            self.publishedAttrs = {};
-            for (var attr in self.attrsToPublish) {
-                self._publishWithRetries(self, attr, self.attrsToPublish[attr], constants.mqtt.retries);
-            }
-            // unpublish
-            for (var attr in self.attrsToRemove) {
-                self._unpublishWithRetries(self, attr, constants.mqtt.retries);
-            }
         } else {
             /*
              * session is present - old subscriptions are still there so we only need to subscribe to new ones
@@ -123,18 +117,19 @@ MQTTRegistry.prototype._prepareForEvents = function() {
             self._subscribeWithRetries(self, JSON.parse(JSON.stringify(self.attrsToSubTo)), constants.mqtt.retries);
             // unsubscribe
             self._unsubscribeWithRetries(self, JSON.parse(JSON.stringify(self.attrsToRemove)), constants.mqtt.retries);
-            // publish
-            for (var attr in self.publishedAttrs) {
-                self.attrsToPublish[attr] = self.publishedAttrs[attr];
-            }
-            self.publishedAttrs = {};
-            for (var attr in self.attrsToPublish) {
-                self._publishWithRetries(self, attr, self.attrsToPublish[attr], constants.mqtt.retries);
-            }
-            // unpublish
-            for (var attr in self.attrsToRemove) {
-                self._unpublishWithRetries(self, attr, constants.mqtt.retries);
-            }
+        }
+
+        // publish
+        for (var attr in self.publishedAttrs) {
+            self.attrsToPublish[attr] = self.publishedAttrs[attr];
+        }
+        self.publishedAttrs = {};
+        for (var attr in self.attrsToPublish) {
+            self._publishWithRetries(self, attr, self.attrsToPublish[attr][payload], self.attrsToPublish[attr][id], constants.mqtt.retries);
+        }
+        // unpublish
+        for (var attr in self.attrsToRemove) {
+            self._unpublishWithRetries(self, attr, constants.mqtt.retries);
         }
     });
 
@@ -162,7 +157,8 @@ MQTTRegistry.prototype._prepareForEvents = function() {
             return;
         }
 
-        self._handleMessage(self, machType, machId, attr, JSON.parse(message.toString()).payload);
+        const parsedMsg = JSON.parse(message.toString());
+        self._handleMessage(self, machType, machId, attr, parsedMsg.payload, parsedMsg.id);
     });
 
     this.client.on('offline', function () {
@@ -179,11 +175,11 @@ MQTTRegistry.prototype._prepareForEvents = function() {
  * Handles receipt of a message from the MQTT broker. Finds the subscription that
  * the message corresponds to and executes the appropriate action.
  */
-MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, message) {
+MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, payload, id) {
     var eventName;
     if (self.subscribedAttrs[machType].hasOwnProperty(attr)) {
         if (attr === 'status') {
-            if (message === 'offline') {
+            if (payload === 'offline') {
                 eventName = self.subscribedAttrs[machType].status.offline;
             } else {
                 eventName = self.subscribedAttrs[machType].status.online;
@@ -194,9 +190,9 @@ MQTTRegistry.prototype._handleMessage = function(self, machType, machId, attr, m
     }
 
     if (eventName !== undefined) {
-        self.emit('discovery', attr, eventName, machId, message);
+        self.emit('discovery', attr, eventName, machId, payload, id);
     } else {
-        console.log('Message received yet we are not subscribed to this message, or shouldn\'t be... This should not be because we are still awaiting a subscription confirmation for this message, as this issue has been fixed. If you ever see this message, then something is probably wrong.');
+        console.log('Message received yet we are not subscribed to this message channel, or shouldn\'t be... This should not be because we are still awaiting a subscription confirmation for this message, as this issue has been fixed. If you ever see this message, then something is probably wrong.');
     }
 }
 
@@ -358,25 +354,29 @@ MQTTRegistry.prototype.unsubscribe = function(self, dattrs) {
 }
 
 /**
- * Helper for publishing an attribute with retries
+ * Helper for publishing an attribute with retries.
+ * attr - the name of the attribute
+ * value - the value of the attribute
+ * msgId - the ID of the publication
+ * retries - the number of retries, if publishing fails
  */
-MQTTRegistry.prototype._publishWithRetries = function(self, attr, value, retries) {
+MQTTRegistry.prototype._publishWithRetries = function(self, attr, value, msgId, retries) {
     var msg;
     if (value instanceof Function) {
-        msg = JSON.stringify({ payload: value() });
+        msg = JSON.stringify({ payload: value(), id: msgId });
     } else {
-        msg = JSON.stringify({ payload: value });
+        msg = JSON.stringify({ payload: value, id: msgId });
     }
     self.client.publish(self.app + '/' + self.machType + '/' + self.id + '/' + attr, msg, {qos: self.pubQos, retain: true}, function (err) {
         if (err) {
             if (retries === 0) {
-                setTimeout(self._publishWithRetries, constants.mqtt.retryInterval, self, attr, value, retries - 1);
+                setTimeout(self._publishWithRetries, constants.mqtt.retryInterval, self, attr, value, msgId, retries - 1);
             } else {
                 self.emit('pub-error', self, attr, value);
             }
         } else {
             // move the attribute from attrsToPublish to publishedAttrs
-            self.publishedAttrs[attr] = value;
+            self.publishedAttrs[attr] = { payload: value, id: msgId };
             delete self.attrsToPublish[attr];
         }
     });
@@ -444,23 +444,27 @@ MQTTRegistry.prototype._getConnectionOptions = function() {
 //==============================================================================
 
 /**
- * Add and publish discoverable attributes for this node
+ * Add and publish attributes for this node
  */
-MQTTRegistry.prototype.addAttributes = function(attrs) {
+MQTTRegistry.prototype.addAttributes = function(attrs, msgId) {
     for (var attr in attrs) {
         // just in case this is in the queue for removal...
         delete this.attrsToRemove[attr];
         // check that it's not already published
         if (!this.publishedAttrs.hasOwnProperty(attr)) {
-            this.attrsToPublish[attr] = attrs[attr];
+            this.attrsToPublish[attr] = { payload: attrs[attr], id: msgId };
             if (this.client && this.client.connected) {
                 // try to publish the attribute
-                this._publishWithRetries(this, attr, attrs[attr], constants.mqtt.retries);
+                this._publishWithRetries(this, attr, attrs[attr], msgId, constants.mqtt.retries);
             }
         }
     }
 }
 
+/**
+ * Unpublishes the given attributes.
+ * attrs - an array of the names (strings) of the attributes to remove.
+ */
 MQTTRegistry.prototype.removeAttributes = function(attrs) {
     for (var i = 0; i < attrs.length; i++) {
         // remove it from attrsToPublish, if need be


### PR DESCRIPTION
Refactored code to change the way we detect duplicates. This method uses a time stamp as a "dedupe identifier". It relies on the assumption that a node will not attempt to publish a different value for an attribute within a millisecond of having last published a value for the attribute. As identifiers are timestamps, they are relatively short. However, they will grow in time (but at a very slow rate).