### PR TITLE
Removed unnecessary callback parameter

### DIFF
--- a/lib/jdiscovery/jregistrar.js
+++ b/lib/jdiscovery/jregistrar.js
@@ -189,27 +189,27 @@ function Registrar(app, machType, id, port, config) {
     var self = this;
 
     if (this.mqttRegistry) {
-        this.mqttRegistry.on('sub-error', function(self, dattrs) {
-            setTimeout(self.mqttRegistry.subscribe, constants.mqtt.longRetryInterval, self, dattrs);
+        this.mqttRegistry.on('sub-error', function(dattrs) {
+            setTimeout(self.mqttRegistry.subscribe, constants.mqtt.longRetryInterval, self.mqttRegistry, dattrs);
         });
 
-        this.mqttRegistry.on('subs-denied', function(self, dattrs) {
+        this.mqttRegistry.on('subs-denied', function(dattrs) {
             var err = new Error('MQTT subscriptions denied');
             err.name = 'permissions_err';
             err.value = dattrs;
             self.emit('error', err);
         });
 
-        this.mqttRegistry.on('unsub-error', function(self, dattrs) {
-            setTimeout(self.mqttRegistry.unsubscribe, constants.mqtt.longRetryInterval, self, dattrs);
+        this.mqttRegistry.on('unsub-error', function(dattrs) {
+            setTimeout(self.mqttRegistry.unsubscribe, constants.mqtt.longRetryInterval, self.mqttRegistry, dattrs);
         });
 
-        this.mqttRegistry.on('pub-error', function(self, attr, value) {
-            setTimeout(self.mqttRegistry.publish, constants.mqtt.longRetryInterval, self, attr, value);
+        this.mqttRegistry.on('pub-error', function(attr, value) {
+            setTimeout(self.mqttRegistry.publish, constants.mqtt.longRetryInterval, self.mqttRegistry, attr, value);
         });
 
-        this.mqttRegistry.on('unpub-error', function(self, attr) {
-            setTimeout(self.mqttRegistry.unpublish, constants.mqtt.longRetryInterval, self, attr);
+        this.mqttRegistry.on('unpub-error', function(attr) {
+            setTimeout(self.mqttRegistry.unpublish, constants.mqtt.longRetryInterval, self.mqttRegistry, attr);
         });
 
         this.mqttRegistry.on('discovery', function(attr, event, nodeId, value) {
@@ -222,19 +222,17 @@ function Registrar(app, machType, id, port, config) {
     }
 
     if (this.mdnsRegistry) {
-        this.mdnsRegistry.on('ad-error', function(self, attr, adName, txtRecord) {
+        this.mdnsRegistry.on('ad-error', function(attr, adName, txtRecord) {
             // an ad failed - try again after some time
-            setTimeout(self.mdnsRegistry._createAdvertisementWithRetries, constants.mdns.longRetryInterval, self, attr, adName, txtRecord, 0);
+            setTimeout(self.mdnsRegistry._createAdvertisementWithRetries, constants.mdns.longRetryInterval, self.mdnsRegistry, attr, adName, txtRecord, 0);
         });
 
-        this.mdnsRegistry.on('browser-error', function(self, attr, machType, events) {
+        this.mdnsRegistry.on('browser-error', function(attr, machType, events) {
             // a browser failed - try again after some time
-            // mahesh: changed 'this' to 'self'
-            // still no effect on the error..
             if (attr === 'status') {
-                setTimeout(self.mdnsRegistry._browseForStatus, constants.mdns.longRetryInterval, self, machType, events);
+                setTimeout(self.mdnsRegistry._browseForStatus, constants.mdns.longRetryInterval, self.mdnsRegistry, machType, events);
             } else {
-                setTimeout(self.mdnsRegistry._browse, constants.mdns.longRetryInterval, self, attr, machType, events);
+                setTimeout(self.mdnsRegistry._browse, constants.mdns.longRetryInterval, self.mdnsRegistry, attr, machType, events);
             }
         });
 

--- a/lib/jdiscovery/mdnsregistry.js
+++ b/lib/jdiscovery/mdnsregistry.js
@@ -107,7 +107,7 @@ MDNSRegistry.prototype._handleError = function(self, err, ad, attr, adName, txtR
                 // make sure the ad is stopped
                 ad.stop();
                 // emit the ad info, so the registrar can decide if it wants to retry later
-                self.emit('ad-error', self, attr, addName, txtRecord);
+                self.emit('ad-error', attr, addName, txtRecord);
             } else {
                 setTimeout(self._createAdvertisementWithRetries, constants.mdns.retryInterval, self, attr, adName, txtRecord, retries - 1);
             }
@@ -116,7 +116,7 @@ MDNSRegistry.prototype._handleError = function(self, err, ad, attr, adName, txtR
             logger.log.error('Unhandled service error: ' + err);
             // make sure the ad is stopped
             ad.stop();
-            self.emit('ad-error', self, attr, addName, txtRecord);
+            self.emit('ad-error', attr, addName, txtRecord);
     }
 }
 
@@ -189,7 +189,7 @@ MDNSRegistry.prototype._browse = function(self, attr, machType, events) {
 
     browser.on('error', function(err) {
         browser.stop();
-        self.emit('browser-error', self, attr, machType, events);
+        self.emit('browser-error', attr, machType, events);
     });
 
     browser.start();
@@ -219,7 +219,7 @@ MDNSRegistry.prototype._browseForStatus = function(self, machType, events) {
 
     browser.on('error', function(err) {
         browser.stop();
-        self.emit('browser-error', self, 'status', machType, events);
+        self.emit('browser-error', 'status', machType, events);
     });
 
     browser.start();

--- a/lib/jdiscovery/mqttregistry.js
+++ b/lib/jdiscovery/mqttregistry.js
@@ -260,7 +260,7 @@ MQTTRegistry.prototype._subscribeWithRetries = function(self, dattrs, retries) {
                     delete self.subscribedAttrs.cloud[attr];
                     self.attrsToSubTo.cloud[attr] = dattrs.cloud[attr];
                 }
-                self.emit('sub-error', self, dattrs);
+                self.emit('sub-error', dattrs);
             }
         } else {
             // move any attrs that were denied from subscribedAttrs to attrsToSubTo and
@@ -331,7 +331,7 @@ MQTTRegistry.prototype._unsubscribeWithRetries = function(self, dattrs, retries)
             if (retries > 0) {
                 setTimeout(self._unsubscribeWithRetries, constants.mqtt.retryInterval, self, topics, retries - 1);
             } else {
-                self.emit('unsub-error', self, dattrs);
+                self.emit('unsub-error', dattrs);
             }
         } else {
             for (var attr in dattrs.device) {
@@ -372,7 +372,7 @@ MQTTRegistry.prototype._publishWithRetries = function(self, attr, value, retries
             if (retries === 0) {
                 setTimeout(self._publishWithRetries, constants.mqtt.retryInterval, self, attr, value, retries - 1);
             } else {
-                self.emit('pub-error', self, attr, value);
+                self.emit('pub-error', attr, value);
             }
         } else {
             // move the attribute from attrsToPublish to publishedAttrs
@@ -398,7 +398,7 @@ MQTTRegistry.prototype._unpublishWithRetries = function(self, attr, retries) {
             if (retries > 0) {
                 setTimeout(self._unpublishWithRetries, constants.mqtt.retryInterval, self, attr, retries - 1);
             } else {
-                self.emit('unpub-error', self, attr);
+                self.emit('unpub-error', attr);
             }
         } else {
             // remove the attribute from attrsToRemove and publishedAttrs


### PR DESCRIPTION
Fix for the following error, seen occasionally:

TypeError: Cannot read property '_browse' of undefined
    at MDNSRegistry.<anonymous> (/Users/oryx/JAMScript-beta/lib/jdiscovery/jregistrar.js:237:45)
    at emitMany (events.js:146:13)
    at MDNSRegistry.emit (events.js:223:7)
    at Browser.<anonymous> (/Users/oryx/JAMScript-beta/lib/jdiscovery/mdnsregistry.js:192:14)
    at emitTwo (events.js:125:13)
    at Browser.emit (events.js:213:7)
    at on_resolver_done (/Users/oryx/JAMScript-beta/lib/jdiscovery/mdns/lib/browser.js:28:14)
    at next (/Users/oryx/JAMScript-beta/lib/jdiscovery/mdns/lib/browser.js:100:7)
    at MDNSService.on_get_addr_info_done (/Users/oryx/JAMScript-beta/lib/jdiscovery/mdns/lib/resolver_sequence_tasks.js:88:11)
    at SocketWatcher.MDNSService.self.watcher.callback (/Users/oryx/JAMScript-beta/lib/jdiscovery/mdns/lib/mdns_service.js:18:40)